### PR TITLE
Remove `stable` and `beta` from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: rust
 
 rust:
 - nightly
-- beta
-- stable


### PR DESCRIPTION
Rocket.rs does not currently compile on stable or beta, so our build
will fail until that is no longer the case.